### PR TITLE
[yixuan-dev] fix if utterance.keep_data is false

### DIFF
--- a/prepare_childes.py
+++ b/prepare_childes.py
@@ -958,7 +958,7 @@ def process_utterance(input_line: str, config: ChatConfig) -> Tuple[bool, str, s
 
     # Get configuration
     if not config.utterance.get('keep_data', True):
-        return False, ''
+        return False, '', ''
 
     # Process the speaker token
     speaker = ''


### PR DESCRIPTION
`process_utterance` should return `tuple[bool, str, str]`, so if `utterance.keep_data` is set to `False`, the following unpack will fail:
https://github.com/Mars-tin/PyChildes/blob/de4ed0c1a941c1473570b993c3a5e164b5b669ce/prepare_childes.py#L1185 