### PR TITLE
[yixuan-fix] Drop empty utterance according to paralinguistic config

### DIFF
--- a/prepare_childes.py
+++ b/prepare_childes.py
@@ -813,6 +813,11 @@ def process_utterance(input_line: str, config: ChatConfig) -> Tuple[bool, str, s
     # Process paralinguistic scope markers
     utterance = process_paralinguistic(utterance, config)
 
+    if utterance == '':
+        # Sometimes paralinguistic processing can remove the entire utterance,
+        # In this case this utterance should not be kept.
+        return False, speaker, ''
+
     # Process special forms, must go after paralinguistic
     utterance = process_special_form(utterance, config)
 


### PR DESCRIPTION
Some paralinguistic content (e.g. `[+ exc]`, `[+ bch]`) are required to be dropped according to the config. Previously these will trigger the `process_paralinguistic` function to return an empty string as utterance, which will result in lines with speaker but without utterance content, like:

```plaintext
<EXP>
# should have been experimenter's instructions to <MOT>
```

Can be replicated with `childes/Eng-NA/NewmanRatner/11/5573IH.cha`.



